### PR TITLE
Update jmztab-m to latest available version 1.0.6

### DIFF
--- a/sirius_cli/src/main/resources/sirius_frontend.build.properties
+++ b/sirius_cli/src/main/resources/sirius_frontend.build.properties
@@ -4,7 +4,7 @@ de.unijena.bioinf.siriusFrontend.version=4.9.13-SNAPSHOT
 de.unijena.bioinf.sirius.version=4.6.1
 de.unijena.bioinf.fingerid.version=1.6.0
 9
-de.unijena.bioinf.mztabm.version=1.0.1
+de.unijena.bioinf.mztabm.version=1.0.6
 #
 de.unijena.bioinf.utils.errorReport.softwareName=SIRIUS
 de.unijena.bioinf.sirius.description=SIRIUS is a java-based software framework for discovering a landscape of de-novo identification of metabolites using single and tandem mass spectrometry. SIRIUS uses isotope pattern analysis for detecting the molecular formula and further analyses the fragmentation pattern of a compound using fragmentation trees. Fragmentation trees can be uploaded to CSI:FingerID via a web service, and results can be displayed in the SIRIUS graphical user interface.


### PR DESCRIPTION
The latest publically available version of jmztab-m is 1.0.6 on Maven Central.
https://search.maven.org/artifact/de.isas.mztab/jmztabm-io/1.0.6/jar
